### PR TITLE
Fix belief initialization and type of converged vertices/edges count.

### DIFF
--- a/src/main/scala/sparkle/graph/BP.scala
+++ b/src/main/scala/sparkle/graph/BP.scala
@@ -84,7 +84,7 @@ object BP extends Logging {
         newGraph.edges.foreachPartition(x => {})
         converged = false
       } else {
-        val numConverged = newGraph.edges.aggregate(0)((res, edge) =>
+        val numConverged = newGraph.edges.aggregate(0L)((res, edge) =>
           if (edge.attr.converged) res + 1 else res, (res1, res2) =>
             res1 + res2)
         logInfo("%d/%d edges converged".format(numConverged, numEdges))

--- a/src/main/scala/sparkle/graph/PairwiseBP.scala
+++ b/src/main/scala/sparkle/graph/PairwiseBP.scala
@@ -61,7 +61,7 @@ object PairwiseBP extends Logging  {
         PVertex(newBelief, vertex.prior, maxDiff < eps)
       }.cache()
       newGraph.edges.foreachPartition(x => {})
-      val numConverged = newGraph.vertices.aggregate(0)((res, vertex) =>
+      val numConverged = newGraph.vertices.aggregate(0L)((res, vertex) =>
           if (vertex._2.converged) res + 1 else res, (res1, res2) =>
           res1 + res2)
       logInfo("%d/%d vertices converged".format(numConverged, numVertices))
@@ -114,7 +114,7 @@ object PairwiseBP extends Logging  {
       val fields = line.split(' ')
       val id = fields(0).toLong
       val prior = Variable(fields.tail.map(x => math.log(x.toDouble)))
-      val belief = Variable.fill(prior.size)(0.0)
+      val belief = Variable(prior.cloneValues)
       (id, PVertex(belief, prior))
     }
     val edgeRDD = edges.map { line =>
@@ -149,4 +149,4 @@ case class PEdge(factor: Factor, forwardMessage: Variable, reverseMessage: Varia
   * @param prior prior
   * @param converged true if converged
   */
-case class PVertex(belief: Variable, prior: Variable, converged: Boolean = false)
+case class PVertex(belief: Variable, prior: Variable, converged: Boolean = true)

--- a/src/main/scala/sparkle/graph/TwoStateBP.scala
+++ b/src/main/scala/sparkle/graph/TwoStateBP.scala
@@ -163,7 +163,9 @@ object TwoStateBP extends Logging  {
     val eps = args(4).toDouble
     val vertexRDD = vertices.map { line =>
       val fields = line.split(' ')
-      (fields(0).toLong, BeliefVertex(Array(fields(1).toDouble, fields(2).toDouble), Array(0.0, 0.0), 0.0))
+      (fields(0).toLong,
+        BeliefVertex(Array(fields(1).toDouble, fields(2).toDouble), Array(fields(1).toDouble, fields(2).toDouble), 0.0)
+      )
     }
     val edgeRDD = edges.map { line =>
       val fields = line.split(' ')

--- a/src/main/scala/sparkle/graph/Utils.scala
+++ b/src/main/scala/sparkle/graph/Utils.scala
@@ -107,9 +107,8 @@ object Utils extends Logging {
       val namedFactor = NamedFactor(factorId, varIds, varNumValues, nonZeroNum, indexAndValues)
       // create Variable vertex if factor has only one variable and add factor there as a prior
       if (varNum == 1) {
-        val initialValue = 1.0
         val namedVariable = new NamedVariable(varIds(0),
-          belief = Variable.fill(varNumValues(0))(initialValue),
+          belief = Variable(namedFactor.factor.cloneValues),
           prior = Variable(namedFactor.factor.cloneValues))
         factorBuffer += namedVariable
       } else {


### PR DESCRIPTION
1. Initialize belief with the prior. Set everything to be converged initially so that the check for convergence will not fail for vertices without edges.
2. Set the type of type of the converged vertices/edges count to Long